### PR TITLE
Fixed non fatal error when .env is not present

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,13 +13,9 @@ import (
 )
 
 func main() {
-	err := godotenv.Load()
+	_ = godotenv.Load()
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = config.ReadFromEnvironment()
+	err := config.ReadFromEnvironment()
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Fix `open .env: no such file or directory` error when running inside docker (or with no .env file)